### PR TITLE
chore: fix some missing details

### DIFF
--- a/packages/stdlib/src/ring0/async-generate.js
+++ b/packages/stdlib/src/ring0/async-generate.js
@@ -1,11 +1,14 @@
+// @ts-check
+
 /**
  * Return an async iterable that produces iterator results via `next`.
  *
  * This works around Jessie's forbiddance of Symbol.
  *
  * @template T,TReturn
- * @param {() => IteratorResult<T, TReturn> | Promise<IteratorResult<T,
- * TReturn>>} next produce an iterator result
+ * @param {() => IteratorResult<T, TReturn> |
+ *               Promise<IteratorResult<T, TReturn>>
+ * } next produce a single-step iterator result
  * @returns {AsyncIterable<T>}
  */
 const asyncGenerate = next => {

--- a/packages/stdlib/types/makers.d.ts
+++ b/packages/stdlib/types/makers.d.ts
@@ -1,5 +1,0 @@
-export function makePromise(executor: any): Promise<any>;
-export function makeMap(entriesOrIterable: any): Map<any, any>;
-export function makeSet(values: any): Set<any>;
-export function makeWeakMap(entries: any): WeakMap<object, any>;
-export function makeWeakSet(values: any): WeakSet<object>;


### PR DESCRIPTION
Oops, missed some details due to automerge.

Also, this version is now available on NPM as `jessie.js@0.2.0`.
