### PR TITLE
Clarify usage of Jessie eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@agoric/eslint-config": "0.1.0",
+    "@endo/eslint-config": "^0.3.8",
     "@typescript-eslint/parser": "^4.17.0",
     "ava": "^3.12.1",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "node": ">=12.17.0"
   },
   "devDependencies": {
-    "@agoric/eslint-config": "0.1.0",
     "@endo/eslint-config": "^0.3.8",
     "@typescript-eslint/parser": "^4.17.0",
     "ava": "^3.12.1",
@@ -23,6 +22,7 @@
     "esm": "^3.2.25",
     "lerna": "^3.19.0",
     "lerna-update-wizard": "^0.17.5",
+    "prettier": "^1.19.1",
     "typescript": "^4.0.2"
   },
   "scripts": {
@@ -38,9 +38,7 @@
     "build": "lerna run build"
   },
   "dependencies": {
-    "@agoric/eslint-plugin": "^0.2.3",
-    "patch-package": "^6.2.2",
-    "prettier": "^1.19.1"
+    "patch-package": "^6.2.2"
   },
   "ava": {
     "files": [

--- a/packages/eslint-plugin/lib/index.js
+++ b/packages/eslint-plugin/lib/index.js
@@ -1,21 +1,22 @@
+/* global __dirname module require */
 /**
- * @fileoverview Agoric-specific plugin
+ * @file Agoric-specific plugin
  * @author Agoric
  */
-"use strict";
+
+'use strict';
 
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
-var requireIndex = require("requireindex");
+const requireIndex = require('requireindex');
 
 //------------------------------------------------------------------------------
 // Plugin Definition
 //------------------------------------------------------------------------------
 
-
 // import all rules in lib/rules
-module.exports.rules = requireIndex(__dirname + "/rules");
-module.exports.configs = requireIndex(__dirname + "/configs");
-module.exports.processors = requireIndex(__dirname + "/processors");
+module.exports.rules = requireIndex(`${__dirname}/rules`);
+module.exports.configs = requireIndex(`${__dirname}/configs`);
+module.exports.processors = requireIndex(`${__dirname}/processors`);

--- a/packages/eslint-plugin/lib/processors/use-jessie.js
+++ b/packages/eslint-plugin/lib/processors/use-jessie.js
@@ -1,106 +1,57 @@
+/* global module require */
+
 'use strict';
 
 const USE_JESSIE_BEFORE_FIRST_STATEMENT_REGEXP = /^\s*\/\/\s*@jessie-check\s*$/m;
 const USE_JESSIE_FIRST_STATEMENT_REGEXP = /^('use\s+jessie'|"use\s+jessie"|import\s+('@jessie.js\/transform-this-module'|"jessie.js\/transform-this-module"))/;
 
-// This is all one line so that we don't mess up
-// eslint's error locations.
-//
-// TODO: Generate this from a data structure.
-const jessieRulesOneLine = `\
-/* eslint\
- curly: ['error', 'all']\
-,eqeqeq: ['error', 'always']\
-,no-bitwise: ['error']\
-,no-fallthrough: ['error', { commentPattern: 'fallthrough is not allowed in Jessie' }]\
-,no-restricted-globals: ['error', 'RegExp', 'Date']\
-,no-restricted-syntax: ['error', \
-{\
-  selector: "BinaryExpression[operator='in']",\
-  message: "'in' is not allowed in Jessie",\
-},\
-{\
-  selector: "UpdateExpression[operator='++'][prefix=false]",\
-  message: "postfix '++' is not allowed in Jessie",\
-},\
-{\
-  selector: "UpdateExpression[operator='--'][prefix=false]",\
-  message: "postfix '--' is not allowed in Jessie",\
-},\
-{\
-  selector: "BinaryExpression[operator='instanceof']",\
-  message: "'instanceof' is not allowed in Jessie",\
-},\
-{\
-  selector: 'NewExpression',\
-  message: "'new' is not allowed in Jessie",\
-},\
-{\
-  selector: 'FunctionDeclaration[generator=true]',\
-  message: 'generators are not allowed in Jessie',\
-},\
-{\
-  selector: 'FunctionDeclaration[async=true]',\
-  message: 'async functions are not allowed in Jessie',\
-},\
-{\
-  selector: 'FunctionExpression[async=true]',\
-  message: 'async functions are not allowed in Jessie',\
-},\
-{\
-  selector: 'ArrowFunctionExpression[async=true]',\
-  message: 'async functions are not allowed in Jessie',\
-},\
-{\
-  selector: 'DoWhileStatement',\
-  message: 'do/while statements are not allowed in Jessie',\
-},\
-{\
-  selector: 'ThisExpression',\
-  message: "'this' not allowed in Jessie",\
-},\
-{\
-  selector: "UnaryExpression[operator='delete']",\
-  message: "'delete' not allowed in Jessie",\
-},\
-{\
-  selector: 'ForInStatement',\
-  message: 'for/in statements are not allowed in Jessie; use for/of Object.keys(val).',\
-},\
-{\
-  selector: 'MemberExpression[computed=true][property.type!="Literal"][property.type!="UnaryExpression"]',\
-  message: "computed property names are not allowed in Jessie (except with leading '+')",\
-},\
-{\
-  selector: 'MemberExpression[computed=true][property.type="UnaryExpression"][property.operator!="+"]',\
-  message: 'computed property names are not allowed in Jessie (except with leading '+')',\
-},\
-{\
-  selector: 'Super',\
-  message: "'super' is not allowed in Jessie",\
-},\
-{\
-  selector: 'MetaProperty',\
-  message: "'MetaProperty' is not allowed in Jessie",\
-},\
-{\
-  selector: 'ClassExpression',\
-  message: "'ClassExpression' is not allowed in Jessie",\
-},\
-{\
-  selector: "CallExpression[callee.name='eval']",\
-  message: "'eval' is not allowed in Jessie",\
-},\
-{\
-  selector: 'Literal[regex]',\
-  message: 'regexp literal syntax is not allowed in Jessie',\
-}\
-]\
-,no-var: ['error']\
-,guard-for-in: 'off'\
-,semi: ['error', 'always']\
- */ \
-`;
+const { jessieRules } = require('../use-jessie-rules');
+
+function serializeRuleObject(obj) {
+  if (Object(obj) !== obj) {
+    if (typeof obj === 'string') {
+      if (obj.indexOf("'") < 0) {
+        // Prefer single-quotes.
+        return `'${obj}'`;
+      }
+    }
+    return JSON.stringify(obj);
+  }
+  if (Array.isArray(obj)) {
+    // Regular array.
+    let out = '[';
+    let sep = '';
+    for (const v of obj) {
+      out += `${sep}${serializeRuleObject(v)}`;
+      sep = ',';
+    }
+    return `${out}]`;
+  }
+
+  // "record".
+  let out = '{';
+  let sep = '';
+  Object.entries(obj).forEach(([k, v]) => {
+    // We assume the key is a legitimate eslint keyword.
+    out += `${sep}${k}:${serializeRuleObject(v)}`;
+    sep = ',';
+  });
+  return `${out}}`;
+}
+
+function serializeEslintRules(rules) {
+  let out = '/* eslint';
+  let sep = ' ';
+  Object.entries(rules).forEach(([k, v]) => {
+    // We assume the key is a legitimate eslint keyword.
+    out += `${sep}${k}:${serializeRuleObject(v)}`;
+    sep = ',';
+  });
+  return `${out} */`;
+}
+
+// Generate a single line of eslint rules.
+const jessieRulesOneLine = serializeEslintRules(jessieRules);
 
 function indexOfFirstStatement(text) {
   let i = 0;
@@ -163,7 +114,7 @@ const prependedText = text => {
     prepend += '// ';
   }
   return prepend;
-}
+};
 
 const filenameToPrepend = new Map();
 module.exports = {
@@ -171,9 +122,7 @@ module.exports = {
     const prepend = prependedText(text);
     if (prepend) {
       filenameToPrepend.set(filename, prepend);
-      return [
-        `${prepend}${text}`
-      ];
+      return [`${prepend}${text}`];
     }
     filenameToPrepend.delete(filename);
     return [text];
@@ -183,14 +132,18 @@ module.exports = {
       return [].concat(...messages);
     }
     const prepend = filenameToPrepend.get(filename);
-    const rewritten = messages.flatMap(errors => errors.map(err => {
-      if ('fix' in err) {
-        // Remove the prepension we inserted.
-        const range = err.fix.range.map(offset => Math.max(offset - prepend.length, 0));
-        return { ...err, fix: { ...err.fix, range }};
-      }
-      return err;
-    }));
+    const rewritten = messages.flatMap(errors =>
+      errors.map(err => {
+        if ('fix' in err) {
+          // Remove the prepension we inserted.
+          const range = err.fix.range.map(offset =>
+            Math.max(offset - prepend.length, 0),
+          );
+          return { ...err, fix: { ...err.fix, range } };
+        }
+        return err;
+      }),
+    );
     // console.error('have rewritten', require('util').inspect(rewritten, undefined, Infinity))
     return rewritten;
   },

--- a/packages/eslint-plugin/lib/use-jessie-rules.js
+++ b/packages/eslint-plugin/lib/use-jessie-rules.js
@@ -1,0 +1,99 @@
+/* global exports */
+
+'use strict';
+
+const nono = `not allowed in Jessie`;
+
+exports.jessieRules = {
+  curly: ['error', 'all'],
+  eqeqeq: ['error', 'always'],
+  'no-bitwise': ['error'],
+  'no-fallthrough': ['error', { commentPattern: `fallthrough is ${nono}` }],
+  'no-restricted-globals': ['error', 'RegExp', 'Date'],
+  'no-restricted-syntax': [
+    'error',
+    {
+      selector: `BinaryExpression[operator='in']`,
+      message: `'in' is ${nono}`,
+    },
+    {
+      selector: `UpdateExpression[operator='++'][prefix=false]`,
+      message: `postfix '++' is ${nono}`,
+    },
+    {
+      selector: `UpdateExpression[operator='--'][prefix=false]`,
+      message: `postfix '--' is ${nono}`,
+    },
+    {
+      selector: `BinaryExpression[operator='instanceof']`,
+      message: `'instanceof' is ${nono}`,
+    },
+    {
+      selector: `NewExpression`,
+      message: `'new' is ${nono}`,
+    },
+    {
+      selector: `FunctionDeclaration[generator=true]`,
+      message: `generators are ${nono}`,
+    },
+    {
+      selector: `FunctionDeclaration[async=true]`,
+      message: `async functions are ${nono}`,
+    },
+    {
+      selector: `FunctionExpression[async=true]`,
+      message: `async functions are ${nono}`,
+    },
+    {
+      selector: `ArrowFunctionExpression[async=true]`,
+      message: `async functions are ${nono}`,
+    },
+    {
+      selector: `DoWhileStatement`,
+      message: `do/while statements are ${nono}`,
+    },
+    {
+      selector: `ThisExpression`,
+      message: `'this' is ${nono}`,
+    },
+    {
+      selector: `UnaryExpression[operator='delete']`,
+      message: `'delete' is ${nono}`,
+    },
+    {
+      selector: `ForInStatement`,
+      message: `for/in statements are ${nono}; use for/of Object.keys(val).`,
+    },
+    {
+      selector: `MemberExpression[computed=true][property.type!='Literal'][property.type!='UnaryExpression']`,
+      message: `computed property names are ${nono} (except with leading '+')`,
+    },
+    {
+      selector: `MemberExpression[computed=true][property.type='UnaryExpression'][property.operator!='+']`,
+      message: `computed property names are ${nono} (except with leading '+')`,
+    },
+    {
+      selector: `Super`,
+      message: `'super' is ${nono}`,
+    },
+    {
+      selector: `MetaProperty`,
+      message: `'import.meta' is ${nono}`,
+    },
+    {
+      selector: `ClassExpression`,
+      message: `'ClassExpression' is ${nono}`,
+    },
+    {
+      selector: `CallExpression[callee.name='eval']`,
+      message: `'eval' is ${nono}`,
+    },
+    {
+      selector: `Literal[regex]`,
+      message: `regexp literal syntax is ${nono}`,
+    },
+  ],
+  'no-var': ['error'],
+  'guard-for-in': 'off',
+  semi: ['error', 'always'],
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -27,6 +27,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "eslintConfig": {
+    "plugins": [
+      "@jessie.js"
+    ],
+    "extends": [
+      "@endo"
+    ]
+  },
   "prettier": {
     "trailingComma": "all",
     "singleQuote": true

--- a/packages/stdlib/package.json
+++ b/packages/stdlib/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@agoric/eslint-config": "^0.2.1",
     "@agoric/ses-ava": "^0.1.1",
     "@agoric/swingset-vat": "^0.16.4",
     "@rollup/plugin-commonjs": "^13.0.0",
@@ -67,8 +66,11 @@
     "access": "public"
   },
   "eslintConfig": {
+    "plugins": [
+      "@jessie.js"
+    ],
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/transform-this-module/package.json
+++ b/packages/transform-this-module/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@agoric/eslint-config": "^0.2.1",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "ava": "^3.12.1",
@@ -65,8 +64,11 @@
     "access": "public"
   },
   "eslintConfig": {
+    "plugins": [
+      "@jessie.js"
+    ],
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@agoric/eslint-config": "^0.2.1",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "ava": "^3.12.1",
@@ -65,8 +64,11 @@
     "access": "public"
   },
   "eslintConfig": {
+    "plugins": [
+      "@jessie.js"
+    ],
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,6 +568,20 @@
   resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.1.0.tgz#d321d5b36f16648f0b0b05d96f93501d6a461501"
   integrity sha512-wVBsKkVV3t3mGT1XVoQAYkBpnum/OEJ0kBka3s7PSQnAne0aFmi1P9IIWyHzsoIgdai7ONTpGSgBZIk6X9dOrw==
 
+"@endo/eslint-config@^0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@endo/eslint-config/-/eslint-config-0.3.8.tgz#8f7426557505001b4fecda6a33582581911c99fe"
+  integrity sha512-Q/eIeUq1BnuQstG6SoryndpUrYi2zbZLZho0B2L5L7Vu6pbpc8n3UW898+qqUYSrmHq/eJz34+TQJwmC/bNYfQ==
+  dependencies:
+    "@endo/eslint-plugin" "^0.3.4"
+
+"@endo/eslint-plugin@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@endo/eslint-plugin/-/eslint-plugin-0.3.4.tgz#6cafbc8623792a4ba261708f2e68a063daa131ab"
+  integrity sha512-VEngqWiAD6ip8+XNuT/6X3ThLJgvkpv2zzBy3NeMLXWCVeX86rpPVWW9GqEmY5M5Q+i8e+lCaLNiW59ZR14sKw==
+  dependencies:
+    requireindex "~1.1.0"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,23 +62,6 @@
   dependencies:
     ses "^0.12.6"
 
-"@agoric/eslint-config@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@agoric/eslint-config/-/eslint-config-0.1.0.tgz#f5d3dc16f6db6248f8b756d514dd2b54d92fd9d6"
-  integrity sha512-oOHWOuoS4pK6PF2HPz0wwhHpkbMcTLAfYGA6pz9fYB8O7efal9EJxcLPTbD3uJd6Z2Qd7CJp/Z8Ze06nT9/nQw==
-
-"@agoric/eslint-config@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@agoric/eslint-config/-/eslint-config-0.2.1.tgz#e18d548fbf2d41ed6dce0303402ffed82b4973ba"
-  integrity sha512-0VJdY28OA1q57QnZHPUlmKO3aMe0MAIoYimwvpr2W5PViq5eZQb9CclpMD6Bliosn54Js0S5CCA1V8VBJfIrPA==
-
-"@agoric/eslint-plugin@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@agoric/eslint-plugin/-/eslint-plugin-0.2.3.tgz#29734731b2bcfcb4bb259f531fcf0125772c3bfd"
-  integrity sha512-m0GcNDf4L8WCQMbDrdq7dv4RVYly7YvDm6Xs2C3/Zq2FQGli9TjuR38SA41HXpf1O9Vaz20YpchuLjx/CP8uKQ==
-  dependencies:
-    requireindex "~1.1.0"
-
 "@agoric/eventual-send@^0.13.11":
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.13.11.tgz#9158a0b36dad625527c9ae28e5210b5ad520a53f"


### PR DESCRIPTION
Depend only on `@endo` eslint config and `@jessie.js` eslint plugins.

Implement `@jessie.js` with separate rules that are serialized to the source file prepension.
