### PR TITLE
feat(eslint-plugin): accept the syntax currently allowed at Agoric

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,6 +1,6 @@
 # @jessie.js/eslint-plugin
 
-Agoric-specific plugin
+Jessie-specific plugin
 
 ## Installation
 
@@ -31,16 +31,10 @@ Add `@jessie.js` to the plugins section of your `.eslintrc` configuration file. 
 ```
 
 
-Then configure the rules you want to use under the rules section.
+Then configure the Jessie parser under the processor section.
 
 ```json
 {
-    "rules": {
-        "@jessie.js/rule-name": 2
-    }
+    "processor": "@jessie.js/use-jessie"
 }
 ```
-
-## Supported Rules
-
-* Fill in provided rules here

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -1,4 +1,5 @@
 /* global module */
 module.exports = {
+  plugins: ['@jessie.js'],
   processor: '@jessie.js/use-jessie',
 };

--- a/packages/eslint-plugin/lib/index.js
+++ b/packages/eslint-plugin/lib/index.js
@@ -18,3 +18,4 @@ const requireIndex = require('requireindex');
 
 module.exports.configs = requireIndex(`${__dirname}/configs`);
 module.exports.processors = requireIndex(`${__dirname}/processors`);
+module.exports.rules = requireIndex(`${__dirname}/rules`);

--- a/packages/eslint-plugin/lib/processors/use-jessie.js
+++ b/packages/eslint-plugin/lib/processors/use-jessie.js
@@ -113,6 +113,8 @@ const prependedText = text => {
   if (text.startsWith('#!')) {
     prepend += '//';
   }
+  // Adding exactly one space to our prepension prevents eslint from insisting
+  // on users adding an extra one themselves.
   if (!prepend.endsWith(' ')) {
     prepend += ' ';
   }

--- a/packages/eslint-plugin/lib/processors/use-jessie.js
+++ b/packages/eslint-plugin/lib/processors/use-jessie.js
@@ -111,7 +111,10 @@ const prependedText = text => {
   }
   let prepend = jessieRulesOneLine;
   if (text.startsWith('#!')) {
-    prepend += '// ';
+    prepend += '//';
+  }
+  if (!prepend.endsWith(' ')) {
+    prepend += ' ';
   }
   return prepend;
 };

--- a/packages/eslint-plugin/lib/rules/no-nested-await.js
+++ b/packages/eslint-plugin/lib/rules/no-nested-await.js
@@ -37,7 +37,7 @@ module.exports = {
       category: 'Possible Errors',
       recommended: true,
       url:
-        'https://github.com/endojs/Jessie/blob/master/packages/eslint-plugin/lib/rules/no-tricky-await.js',
+        'https://github.com/endojs/Jessie/blob/master/packages/eslint-plugin/lib/rules/no-nested-await.js',
     },
     type: 'problem',
     fixable: null,

--- a/packages/eslint-plugin/lib/rules/no-nested-await.js
+++ b/packages/eslint-plugin/lib/rules/no-nested-await.js
@@ -47,6 +47,11 @@ module.exports = {
   create(context) {
     return {
       AwaitExpression: node => {
+        // As a hint to future readers, I used the following ASTExplorer
+        // workspace to look up the relevant AST shapes (note that node.parent
+        // is not displayed in the ASTExplorer, but is available in the ESLint
+        // visitor):
+        // https://astexplorer.net/#/gist/4508eec25a8d5be1e0248c4cc06b9634/f6b22f2e8e3abd82a911ca6286a304ef0a3018c4
         let parent = node.parent;
         if (parent.type === 'VariableDeclarator' && parent.init === node) {
           // It's a declarator, so look up to the declaration statement's parent.

--- a/packages/eslint-plugin/lib/rules/no-tricky-await.js
+++ b/packages/eslint-plugin/lib/rules/no-tricky-await.js
@@ -1,0 +1,88 @@
+/* global module, require */
+/**
+ * @author Michael FIG
+ * See LICENSE file in root direcotry for full license.
+ */
+
+'use strict';
+
+/**
+ * Imports a specific module.
+ *
+ * @param {...string} moduleNames - module names to import.
+ * @returns {object|null} The imported object, or null.
+ */
+function safeRequire(...moduleNames) {
+  for (const moduleName of moduleNames) {
+    try {
+      // eslint-disable-next-line import/no-dynamic-require,global-require
+      return require(moduleName);
+    } catch (_err) {
+      // Ignore.
+    }
+  }
+  return null;
+}
+
+const CodePathAnalyzer = safeRequire(
+  'eslint/lib/linter/code-path-analysis/code-path-analyzer',
+  'eslint/lib/code-path-analysis/code-path-analyzer',
+);
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'prevent usage of `await` unless it is a function block statement or destructuring assignment',
+      category: 'Possible Errors',
+      recommended: true,
+      url:
+        'https://github.com/endojs/Jessie/blob/master/packages/eslint-plugin/lib/rules/no-tricky-await.js',
+    },
+    type: 'problem',
+    fixable: null,
+    schema: [],
+    supported: true || CodePathAnalyzer !== null,
+  },
+  create(context) {
+    return {
+      AwaitExpression: node => {
+        let parent = node.parent;
+        if (parent.type === 'VariableDeclarator' && parent.init === node) {
+          // It's a declarator, so look up to the declaration statement's parent.
+          parent = parent.parent.parent;
+        } else if (
+          parent.type === 'AssignmentExpression' &&
+          parent.right === node
+        ) {
+          // It's an assignment, so look up to the assigment's parent.
+          parent = parent.parent;
+          if (parent.type === 'ExpressionStatement') {
+            // Try to find the parent block.
+            parent = parent.parent;
+          }
+        }
+        if (parent.type === 'BlockStatement') {
+          // Find the parent block's node.
+          parent = parent.parent;
+        }
+
+        if (
+          [
+            'ArrowFunctionExpression',
+            'FunctionExpression',
+            'FunctionDeclaration',
+          ].includes(parent.type)
+        ) {
+          // Its parent is a function body.
+          return;
+        }
+
+        context.report({
+          node,
+          message: 'Unexpected `await` expression (not top of function body)',
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/lib/use-jessie-rules.js
+++ b/packages/eslint-plugin/lib/use-jessie-rules.js
@@ -5,11 +5,13 @@
 const nono = `not allowed in Jessie`;
 
 exports.jessieRules = {
+  '@jessie.js/no-tricky-await': ['error'],
   curly: ['error', 'all'],
   eqeqeq: ['error', 'always'],
   'no-bitwise': ['error'],
   'no-fallthrough': ['error', { commentPattern: `fallthrough is ${nono}` }],
-  'no-restricted-globals': ['error', 'RegExp', 'Date'],
+  // The denylist is probably too permissive.  We should have an allowlist.
+  'no-restricted-globals': ['error', 'RegExp', 'Date', 'Symbol'],
   'no-restricted-syntax': [
     'error',
     {
@@ -17,36 +19,20 @@ exports.jessieRules = {
       message: `'in' is ${nono}`,
     },
     {
-      selector: `UpdateExpression[operator='++'][prefix=false]`,
-      message: `postfix '++' is ${nono}`,
-    },
-    {
-      selector: `UpdateExpression[operator='--'][prefix=false]`,
-      message: `postfix '--' is ${nono}`,
-    },
-    {
       selector: `BinaryExpression[operator='instanceof']`,
-      message: `'instanceof' is ${nono}`,
+      message: `'instanceof' is ${nono}; use duck typing`,
     },
     {
       selector: `NewExpression`,
-      message: `'new' is ${nono}`,
+      message: `'new' is ${nono}; use a 'maker' function`,
     },
     {
       selector: `FunctionDeclaration[generator=true]`,
       message: `generators are ${nono}`,
     },
     {
-      selector: `FunctionDeclaration[async=true]`,
-      message: `async functions are ${nono}`,
-    },
-    {
-      selector: `FunctionExpression[async=true]`,
-      message: `async functions are ${nono}`,
-    },
-    {
-      selector: `ArrowFunctionExpression[async=true]`,
-      message: `async functions are ${nono}`,
+      selector: `FunctionExpression[generator=true]`,
+      message: `generators are ${nono}`,
     },
     {
       selector: `DoWhileStatement`,
@@ -54,23 +40,23 @@ exports.jessieRules = {
     },
     {
       selector: `ThisExpression`,
-      message: `'this' is ${nono}`,
+      message: `'this' is ${nono}; use a closed-over lexical variable instead`,
     },
     {
       selector: `UnaryExpression[operator='delete']`,
-      message: `'delete' is ${nono}`,
+      message: `'delete' is ${nono}; destructure objects and reassemble them without mutation`,
     },
     {
       selector: `ForInStatement`,
-      message: `for/in statements are ${nono}; use for/of Object.keys(val).`,
+      message: `for/in statements are ${nono}; use for/of Object.keys(val)`,
     },
     {
       selector: `MemberExpression[computed=true][property.type!='Literal'][property.type!='UnaryExpression']`,
-      message: `computed property names are ${nono} (except with leading '+')`,
+      message: `arbitrary computed property names are ${nono}; use leading '+'`,
     },
     {
       selector: `MemberExpression[computed=true][property.type='UnaryExpression'][property.operator!='+']`,
-      message: `computed property names are ${nono} (except with leading '+')`,
+      message: `arbitrary computed property names are ${nono}; use leading '+'`,
     },
     {
       selector: `Super`,
@@ -82,7 +68,11 @@ exports.jessieRules = {
     },
     {
       selector: `ClassExpression`,
-      message: `'ClassExpression' is ${nono}`,
+      message: `'class' is ${nono}; define a 'maker' function`,
+    },
+    {
+      selector: `ClassDeclaration`,
+      message: `'class' is ${nono}; define a 'maker' function`,
     },
     {
       selector: `CallExpression[callee.name='eval']`,

--- a/packages/eslint-plugin/lib/use-jessie-rules.js
+++ b/packages/eslint-plugin/lib/use-jessie-rules.js
@@ -5,7 +5,7 @@
 const nono = `not allowed in Jessie`;
 
 exports.jessieRules = {
-  '@jessie.js/no-tricky-await': ['error'],
+  '@jessie.js/no-nested-await': ['error'],
   curly: ['error', 'all'],
   eqeqeq: ['error', 'always'],
   'no-bitwise': ['error'],

--- a/packages/eslint-plugin/lib/use-jessie-rules.js
+++ b/packages/eslint-plugin/lib/use-jessie-rules.js
@@ -12,6 +12,10 @@ exports.jessieRules = {
   'no-fallthrough': ['error', { commentPattern: `fallthrough is ${nono}` }],
   // The denylist is probably too permissive.  We should have an allowlist.
   'no-restricted-globals': ['error', 'RegExp', 'Date', 'Symbol'],
+  // Hint to future readers: https://eslint.org/docs/developer-guide/selectors
+  // is a guide to the `no-restricted-syntax` rule configuration.  You can use
+  // https://astexplorer.net/#/gist/4508eec25a8d5be1e0248c4cc06b9634/f6b22f2e8e3abd82a911ca6286a304ef0a3018c4
+  // to see what AST nodes are produced by different programs.
   'no-restricted-syntax': [
     'error',
     {


### PR DESCRIPTION
The most major addition to the `@jessie.js/eslint-plugin` is to enable `async` functions and properly lint the use of `await`.  The rules allow for:

1. `await` expression statements at the top level of an `async` function (either the topmost block or the only expression, if an arrow function).
2. `SOMETHING = await somethingElse;` statements at the function's topmost block or expression.
3. no other use of `await`.

The other changes should be fairly self-explanatory.  They were determined by examining the Jessica grammars for Jessie, driven by @dckc's Agoric/documentation#540.