### PR TITLE
fix(eslint-plugin): Disallow `await` in non-plain assignments

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-nested-await.js
+++ b/packages/eslint-plugin/lib/rules/no-nested-await.js
@@ -58,7 +58,8 @@ module.exports = {
           parent = parent.parent.parent;
         } else if (
           parent.type === 'AssignmentExpression' &&
-          parent.right === node
+          parent.right === node &&
+          parent.operator === '='
         ) {
           // It's an assignment, so look up to the assigment's parent.
           parent = parent.parent;


### PR DESCRIPTION
An non plain assignment operation is one where the lhs is evaluated before the right hand side expression is. For example `a += expr` is the equivalent of `a = a + expr`. While the Jessie rules disallow `a + await expr` we mistakenly allowed `a += await expr`.

Fixes #89 