### PR TITLE
fix(eslint-plugin): Handle for-await-of correctly

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-nested-await.js
+++ b/packages/eslint-plugin/lib/rules/no-nested-await.js
@@ -74,13 +74,15 @@ module.exports = {
         }
 
         if (
-          [
+          ([
             'ArrowFunctionExpression',
             'FunctionExpression',
             'FunctionDeclaration',
-          ].includes(parent.type)
+          ].includes(parent.type) &&
+            parent.async === true) ||
+          (parent.type === 'ForOfStatement' && parent.await === true)
         ) {
-          // Its parent is a function body.
+          // Its parent is an async function or for-await-of body.
           return;
         }
 

--- a/packages/eslint-plugin/lib/rules/no-nested-await.js
+++ b/packages/eslint-plugin/lib/rules/no-nested-await.js
@@ -45,13 +45,13 @@ module.exports = {
     supported: true || CodePathAnalyzer !== null,
   },
   create(context) {
-    const isValidParent = parent => {
+    const isAwaitAllowedInNode = parent => {
       if (parent.type === 'BlockStatement') {
         // Find the parent block's node.
         parent = parent.parent;
       }
 
-      // Is the parent is an async function or for-await-of body.
+      // If the parent is an async function or for-await-of body.
       return (
         ([
           'ArrowFunctionExpression',
@@ -87,19 +87,20 @@ module.exports = {
           parent = parent.parent;
         }
 
-        if (!isValidParent(parent)) {
+        if (!isAwaitAllowedInNode(parent)) {
           context.report({
             node,
-            message: 'Unexpected `await` expression (not top of function body)',
+            message:
+              'Unexpected `await` expression (not top of async function or `for-await-of` body)',
           });
         }
       },
       ForOfStatement: node => {
-        if (node.await === true && !isValidParent(node.parent)) {
+        if (node.await === true && !isAwaitAllowedInNode(node.parent)) {
           context.report({
             node,
             message:
-              'Unexpected `for-await-of` statement (not top of function body)',
+              'Unexpected `for-await-of` statement (not top of async function or another `for-await-of` body)',
           });
         }
       },


### PR DESCRIPTION
According to @erights and @dtribble, an `await` in the top-level of a `for-await-of` block is safe since there is always an interleaving point to both enter and exit the block. It's somewhat equivalent to the body of an async function.

While working on this I realized we were not disallowing for-await-of statements where await expressions would be disallowed, so this PR fixes that as well.

Tested manually.