### PR TITLE
fix(eslint-plugin): prevent top-level effects

### DIFF
--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -2,4 +2,8 @@
 module.exports = {
   plugins: ['@jessie.js'],
   processor: '@jessie.js/use-jessie',
+  globals: {
+    harden: false,
+    assert: false,
+  },
 };

--- a/packages/eslint-plugin/lib/rules/no-top-level-effects.js
+++ b/packages/eslint-plugin/lib/rules/no-top-level-effects.js
@@ -1,0 +1,92 @@
+/* global module, require */
+/**
+ * @author Michael FIG
+ * See LICENSE file in root direcotry for full license.
+ */
+
+'use strict';
+
+const nono = `not allowed in Jessie`;
+
+/**
+ * Imports a specific module.
+ *
+ * @param {...string} moduleNames - module names to import.
+ * @returns {object|null} The imported object, or null.
+ */
+function safeRequire(...moduleNames) {
+  for (const moduleName of moduleNames) {
+    try {
+      // eslint-disable-next-line import/no-dynamic-require,global-require
+      return require(moduleName);
+    } catch (_err) {
+      // Ignore.
+    }
+  }
+  return null;
+}
+
+const CodePathAnalyzer = safeRequire(
+  'eslint/lib/linter/code-path-analysis/code-path-analyzer',
+  'eslint/lib/code-path-analysis/code-path-analyzer',
+);
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'prevent top-level code evaluation',
+      category: 'Possible Errors',
+      recommended: true,
+      url:
+        'https://github.com/endojs/Jessie/blob/master/packages/eslint-plugin/lib/rules/no-top-level-effects.js',
+    },
+    type: 'problem',
+    fixable: null,
+    schema: [],
+    supported: true || CodePathAnalyzer !== null,
+  },
+  create(context) {
+    let depth = 0;
+    return {
+      ':function': _node => {
+        depth += 1;
+      },
+      ':function:exit': _node => {
+        depth -= 1;
+      },
+      CallExpression: node => {
+        if (depth > 0) {
+          return;
+        }
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'harden'
+        ) {
+          return;
+        }
+        context.report({
+          node,
+          message: `top-level function calls are ${nono}; only 'harden' is allowed`,
+        });
+      },
+      UpdateExpression: node => {
+        if (depth > 0) {
+          return;
+        }
+        context.report({
+          node,
+          message: `top-level mutations are ${nono}; only non-side-effecting ones are allowed`,
+        });
+      },
+      AssignmentExpression: node => {
+        if (depth > 0) {
+          return;
+        }
+        context.report({
+          node,
+          message: `top-level mutating assignments are ${nono}; only bindings are allowed`,
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/lib/use-jessie-rules.js
+++ b/packages/eslint-plugin/lib/use-jessie-rules.js
@@ -6,6 +6,7 @@ const nono = `not allowed in Jessie`;
 
 exports.jessieRules = {
   '@jessie.js/no-nested-await': ['error'],
+  '@jessie.js/no-top-level-effects': ['error'],
   curly: ['error', 'all'],
   eqeqeq: ['error', 'always'],
   'no-bitwise': ['error'],
@@ -18,6 +19,14 @@ exports.jessieRules = {
   // to see what AST nodes are produced by different programs.
   'no-restricted-syntax': [
     'error',
+    {
+      selector: `Program > [type!='ExpressionStatement'][type!='ImportDeclaration'][type!='ExportDefaultDeclaration'][type!='ExportNamedDeclaration'][type!='VariableDeclaration']`,
+      message: `top-level statement of this type is ${nono}`,
+    },
+    {
+      selector: `Program > VariableDeclaration[kind!='const']`,
+      message: `non-'const' top-level variable declarations are ${nono}`,
+    },
     {
       selector: `BinaryExpression[operator='in']`,
       message: `'in' is ${nono}`,


### PR DESCRIPTION
refs: Agoric/agoric-sdk#5632

Linting so that module-level functions don't run on import, and no mutable bindings exist.

Hardening rules need to come later to prevent mutable module data.
