### PR TITLE
ESLint `await` rule cleanup

### DIFF
--- a/packages/eslint-plugin/NEWS.md
+++ b/packages/eslint-plugin/NEWS.md
@@ -1,0 +1,5 @@
+User-visible changes in `@endo/eslint-plugin`
+
+# v0.4.4 (2023-04-14)
+
+- Separate rules into subsets (documented in README.md)

--- a/packages/eslint-plugin/jsconfig.json
+++ b/packages/eslint-plugin/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "moduleResolution": "node",
+    "target": "esnext",
+    "module": "CommonJS",
+    "noImplicitAny": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "alwaysStrict": true,
+    "downlevelIteration": true
+  },
+  "include": ["lib/**/*.js"],
+  "exclude": ["node_modules/**"]
+}

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -5,4 +5,7 @@
 module.exports = {
   plugins: ['@jessie.js'],
   processor: '@jessie.js/use-jessie',
+  rules: {
+    '@jessie.js/safe-await-separator': 'warn',
+  },
 };

--- a/packages/eslint-plugin/lib/rules/no-nested-await.js
+++ b/packages/eslint-plugin/lib/rules/no-nested-await.js
@@ -1,4 +1,6 @@
+// @ts-check
 /* eslint-env node */
+
 /**
  * @author Michael FIG
  * See LICENSE file in root directory for full license.
@@ -8,6 +10,7 @@
 
 const { makeAwaitAllowedVisitor } = require('../tools.js');
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {
@@ -26,6 +29,9 @@ module.exports = {
     supported: true,
   },
   create(context) {
+    /**
+     * @param {import('eslint').Rule.Node} node
+     */
     const makeReport = node => {
       context.report({
         node,

--- a/packages/eslint-plugin/lib/rules/safe-await-separator.js
+++ b/packages/eslint-plugin/lib/rules/safe-await-separator.js
@@ -1,4 +1,6 @@
+// @ts-check
 /* eslint-env node */
+
 /**
  * @author Michael FIG
  * See LICENSE file in root directory for full license.
@@ -8,6 +10,7 @@
 
 const { isFunctionLike, makeAwaitAllowedVisitor } = require('../tools.js');
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {
@@ -29,6 +32,9 @@ module.exports = {
     supported: true,
   },
   create(context) {
+    /**
+     * @param {import('eslint').Rule.Node} node
+     */
     const makeReport = node => {
       context.report({
         node,

--- a/packages/eslint-plugin/lib/rules/safe-await-separator.js
+++ b/packages/eslint-plugin/lib/rules/safe-await-separator.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const { makeAwaitAllowedVisitor } = require('../tools.js');
+const { isFunctionLike, makeAwaitAllowedVisitor } = require('../tools.js');
 
 module.exports = {
   meta: {
@@ -19,9 +19,11 @@ module.exports = {
     },
     type: 'problem',
     fixable: null,
+    hasSuggestions: true,
     messages: {
       unsafeAwaitSeparator:
         'The first `await` appearing in an async function must not be nested',
+      insertAwaitNull: 'Insert `await null;` before the first `await`',
     },
     schema: [],
     supported: true,
@@ -31,6 +33,20 @@ module.exports = {
       context.report({
         node,
         messageId: 'unsafeAwaitSeparator',
+        suggest: [
+          {
+            messageId: 'insertAwaitNull',
+            fix: fixer => {
+              let cur = node;
+              let parent = cur.parent;
+              while (!isFunctionLike(parent.parent)) {
+                cur = parent;
+                parent = cur.parent;
+              }
+              return fixer.insertTextBefore(cur, 'await null;');
+            },
+          },
+        ],
       });
     };
     return makeAwaitAllowedVisitor(context, makeReport, true);

--- a/packages/eslint-plugin/lib/rules/safe-await-separator.js
+++ b/packages/eslint-plugin/lib/rules/safe-await-separator.js
@@ -11,16 +11,17 @@ const { makeAwaitAllowedVisitor } = require('../tools.js');
 module.exports = {
   meta: {
     docs: {
-      description: `ensure all \`await\`s in an \`async\` function are not nested`,
+      description: `ensure the first \`await\` in an \`async\` function is non-nested so that it is clear when the synchronous portion of the function is finished`,
       category: 'Possible Errors',
       recommended: true,
       url:
-        'https://github.com/endojs/Jessie/blob/main/packages/eslint-plugin/lib/rules/no-nested-await.js',
+        'https://github.com/endojs/Jessie/blob/main/packages/eslint-plugin/lib/rules/safe-await-separator',
     },
     type: 'problem',
     fixable: null,
     messages: {
-      unexpectedNestedAwait: 'Nested `await`s are not permitted in Jessie',
+      unsafeAwaitSeparator:
+        'The first `await` appearing in an async function must not be nested',
     },
     schema: [],
     supported: true,
@@ -29,9 +30,9 @@ module.exports = {
     const makeReport = node => {
       context.report({
         node,
-        messageId: 'unexpectedNestedAwait',
+        messageId: 'unsafeAwaitSeparator',
       });
     };
-    return makeAwaitAllowedVisitor(context, makeReport);
+    return makeAwaitAllowedVisitor(context, makeReport, true);
   },
 };

--- a/packages/eslint-plugin/lib/tools.js
+++ b/packages/eslint-plugin/lib/tools.js
@@ -1,0 +1,111 @@
+/* eslint-env node */
+
+'use strict';
+
+const isFunctionLike = node =>
+  [
+    'ArrowFunctionExpression',
+    'FunctionExpression',
+
+    'FunctionDeclaration',
+    'MethodDefinition',
+
+    'Program',
+    'StaticBlock',
+  ].includes(node.type);
+
+const isAwaitAllowedInNode = (node, already = new WeakSet()) => {
+  // Climb the AST until finding the nearest enclosing function or
+  // function-like node.
+  let result = true;
+  for (; node && !isFunctionLike(node); node = node.parent) {
+    if (already.has(node)) {
+      return true;
+    }
+    already.add(node);
+
+    if (node.type === 'BlockStatement') {
+      // do nothing
+    } else if (node.type === 'ForOfStatement' && node.await) {
+      // do nothing
+    } else {
+      // Encountering anything other than an enclosing block is grounds for
+      // rejection.
+      result = false;
+    }
+  }
+
+  if (!node) {
+    // Should never reach here because Program is a FunctionLike for
+    // top-level await.
+    throw new Error(`unexpected non-Program AST!`);
+  }
+
+  return result;
+};
+
+const makeAwaitAllowedVisitor = (
+  _context,
+  makeReport,
+  addToCache = undefined,
+) => {
+  const already = addToCache ? new WeakSet() : undefined;
+  return {
+    /**
+     * An `await` expression is treated as non-nested if it is:
+     * - a non-nested expression statement,
+     * - the right-hand side of a non-nested declarator, or
+     * - the right-hand side of an assignment expression.
+     *
+     * As a hint to future readers, the following ASTExplorer workspace
+     * reveals some of the relevant AST shapes (note that node.parent is not
+     * displayed in the ASTExplorer, but is available in the ESLint visitor):
+     *
+     * @see https://astexplorer.net/#/gist/4508eec25a8d5be1e0248c4cc06b9634/f6b22f2e8e3abd82a911ca6286a304ef0a3018c4
+     *
+     * This will need different handling for do expressions if they are ever
+     * added to the language.
+     * @see https://github.com/tc39/proposal-do-expressions
+     *
+     * @param {*} node
+     */
+    AwaitExpression: node => {
+      let parent = node.parent;
+      if (parent.type === 'VariableDeclarator' && parent.init === node) {
+        // It's a declarator, so look up to the declaration statement's parent.
+        parent = parent.parent.parent;
+      } else if (
+        parent.type === 'AssignmentExpression' &&
+        parent.right === node &&
+        parent.operator === '='
+      ) {
+        // It's an assignment, so look up to the assigment's parent.
+        parent = parent.parent;
+      }
+      if (parent.type === 'ExpressionStatement') {
+        // Try to find the parent block.
+        parent = parent.parent;
+      }
+
+      if (!isAwaitAllowedInNode(parent, already)) {
+        makeReport(node);
+      }
+    },
+    /**
+     * A `for-await-of` loop is treated as a simple `await` statement.
+     *
+     * @param {*} node
+     */
+    'ForOfStatement[await=true]': node => {
+      if (!isAwaitAllowedInNode(node.parent, already)) {
+        makeReport(node);
+      }
+    },
+  };
+};
+
+module.exports = {
+  isFunctionLike,
+  isAwaitAllowedInNode,
+  makeAwaitAllowedVisitor,
+};

--- a/packages/eslint-plugin/test/test-no-nested-await.js
+++ b/packages/eslint-plugin/test/test-no-nested-await.js
@@ -9,12 +9,16 @@ const ruleTester = new RuleTester({
   parserOptions: { sourceType: 'module', ecmaVersion: 2021 },
 });
 const rule = require('../lib/rules/no-nested-await.js');
-const { clearlyValid, subtlyValid, clearlyInvalid } = require('./corpus.js');
+const {
+  validNoNestedAwait,
+  subtlyValid,
+  clearlyInvalid,
+} = require('./corpus.js');
 
 const unexpectedNestedAwait = 'unexpectedNestedAwait';
 
 ruleTester.run('no-nested-await', rule, {
-  valid: clearlyValid,
+  valid: validNoNestedAwait,
   // `no-nested-await` is not smart enough to ignore subtle code that is
   // actually valid.  We test that it fails these cases.
   invalid: [...clearlyInvalid, ...subtlyValid].map(example => ({

--- a/packages/eslint-plugin/test/test-safe-await-separator.js
+++ b/packages/eslint-plugin/test/test-safe-await-separator.js
@@ -1,0 +1,36 @@
+/* eslint-env node */
+
+'use strict';
+
+// Convenience utility using Mocha globals.
+const { RuleTester } = require('eslint');
+
+const ruleTester = new RuleTester({
+  parserOptions: { sourceType: 'module', ecmaVersion: 2021 },
+});
+const rule = require('../lib/rules/safe-await-separator.js');
+const {
+  validSafeAwaitSeparator,
+  subtlyValid,
+  clearlyInvalid,
+} = require('./corpus.js');
+
+const unsafeAwaitSeparator = 'unsafeAwaitSeparator';
+
+ruleTester.run('safe-await-separator', rule, {
+  valid: validSafeAwaitSeparator,
+  // `safe-await-separator` is not smart enough to ignore subtle code that is
+  // actually valid.  We test that it fails these cases.
+  invalid: [...clearlyInvalid, ...subtlyValid].map(example => ({
+    ...example,
+    errors: example.errors
+      .filter(
+        error =>
+          !error.messageId || error.messageId !== 'unexpectedNestedAwait',
+      )
+      .map(error => ({
+        ...error,
+        messageId: unsafeAwaitSeparator,
+      })),
+  })),
+});

--- a/packages/eslint-plugin/test/test-safe-await-separator.js
+++ b/packages/eslint-plugin/test/test-safe-await-separator.js
@@ -15,8 +15,6 @@ const {
   clearlyInvalid,
 } = require('./corpus.js');
 
-const unsafeAwaitSeparator = 'unsafeAwaitSeparator';
-
 ruleTester.run('safe-await-separator', rule, {
   valid: validSafeAwaitSeparator,
   // `safe-await-separator` is not smart enough to ignore subtle code that is
@@ -30,7 +28,7 @@ ruleTester.run('safe-await-separator', rule, {
       )
       .map(error => ({
         ...error,
-        messageId: unsafeAwaitSeparator,
+        messageId: 'unsafeAwaitSeparator',
       })),
   })),
 });

--- a/packages/stdlib/test/test-async-tools.js
+++ b/packages/stdlib/test/test-async-tools.js
@@ -38,12 +38,18 @@ test('asyncGenerate - manual iteration', async t => {
   });
 
   const ai = gen[Symbol.asyncIterator]();
-  for (let count = 0; count < 4; count += 1) {
-    // eslint-disable-next-line no-await-in-loop
-    const r = await ai.next();
-    t.is(r.done, false);
-    t.is(r.value, count);
-  }
+  const r0 = await ai.next();
+  t.is(r0.done, false);
+  t.is(r0.value, 0);
+  const r1 = await ai.next();
+  t.is(r1.done, false);
+  t.is(r1.value, 1);
+  const r2 = await ai.next();
+  t.is(r2.done, false);
+  t.is(r2.value, 2);
+  const r3 = await ai.next();
+  t.is(r3.done, false);
+  t.is(r3.value, 3);
   const fin = await ai.next();
   t.is(fin.done, true);
   t.is(fin.value, 4);

--- a/packages/stdlib/test/test-e.js
+++ b/packages/stdlib/test/test-e.js
@@ -41,9 +41,10 @@ test('E method calls', async t => {
       return 2 * n;
     },
   };
-  const d = E(x).double(6);
-  t.is(typeof d.then, 'function', 'return is a thenable');
-  t.is(await d, 12, 'method call works');
+  const dP = E(x).double(6);
+  t.is(typeof dP.then, 'function', 'return is a thenable');
+  const d = await dP;
+  t.is(d, 12, 'method call works');
 });
 
 test('E sendOnly method calls', async t => {
@@ -129,6 +130,7 @@ test('E shortcuts', async t => {
       return `${greeting}, ${this.name}!`;
     },
   };
+  await null;
   t.is(await E(x).hello('Hello'), 'Hello, buddy!', 'method call works');
   t.is(
     await E(await E.get(await E.get(x).y).fn)(4),
@@ -151,6 +153,7 @@ test('E.get', async t => {
       return `${greeting}, ${this.name}!`;
     },
   };
+  await null;
   t.is(
     await E(await E.get(await E.get(x).y).fn)(4),
     8,


### PR DESCRIPTION
Closes #107

Separate the recommended `@jessie.js/safe-await-separator` rule from the `@jessie.js/no-nested-await` rule (now activated by `// @jessie-check`).

This should be the final step before upgrading the `@jessie.js/eslint-plugin` package used by the Agoric SDK.
