### PR TITLE
chore(release): publish 2024-03-28

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.1](https://github.com/endojs/Jessie/compare/@jessie.js/eslint-plugin@0.4.0...@jessie.js/eslint-plugin@0.4.1) (2024-03-28)
+
+
+### Bug Fixes
+
+* drop sometimes superfluous max-len ([8d5bd0c](https://github.com/endojs/Jessie/commit/8d5bd0c90ad7facff8826af8896f5c00eaf83520))
+
+
+
+
+
 # [0.4.0](https://github.com/endojs/Jessie/compare/@jessie.js/eslint-plugin@0.3.0...@jessie.js/eslint-plugin@0.4.0) (2023-06-01)
 
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jessie.js/eslint-plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Jessie-specific ESLint plugin",
   "keywords": [
     "eslint",

--- a/packages/parse/CHANGELOG.md
+++ b/packages/parse/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.4](https://github.com/endojs/Jessie/compare/@jessie.js/parse@0.2.3...@jessie.js/parse@0.2.4) (2024-03-28)
+
+**Note:** Version bump only for package @jessie.js/parse
+
+
+
+
+
 ## [0.2.3](https://github.com/endojs/Jessie/compare/@jessie.js/parse@0.2.2...@jessie.js/parse@0.2.3) (2023-06-01)
 
 **Note:** Version bump only for package @jessie.js/parse

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jessie.js/parse",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Jessie parser generator",
   "type": "module",
   "keywords": [],
@@ -35,7 +35,7 @@
     "@endo/far": "^1.0.0",
     "@endo/init": "^1.0.0",
     "@jessie.js/transform-this-module": "^0.2.3",
-    "jessie.js": "^0.3.3"
+    "jessie.js": "^0.3.4"
   },
   "devDependencies": {
     "@endo/ses-ava": "^1.0.0",

--- a/packages/stdlib/CHANGELOG.md
+++ b/packages/stdlib/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.4](https://github.com/endojs/Jessie/compare/jessie.js@0.3.3...jessie.js@0.3.4) (2024-03-28)
+
+**Note:** Version bump only for package jessie.js
+
+
+
+
+
 ## [0.3.3](https://github.com/endojs/Jessie/compare/jessie.js@0.3.2...jessie.js@0.3.3) (2023-06-01)
 
 

--- a/packages/stdlib/package.json
+++ b/packages/stdlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jessie.js",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Jessie standard library",
   "type": "module",
   "keywords": [],


### PR DESCRIPTION
 - @jessie.js/eslint-plugin@0.4.1
 - @jessie.js/parse@0.2.4
 - jessie.js@0.3.4