### PR TITLE
Make Jessie ESLint Plugin ESLint v9 compatible

### DIFF
--- a/packages/eslint-plugin/lib/tools.js
+++ b/packages/eslint-plugin/lib/tools.js
@@ -73,6 +73,7 @@ const makeAwaitAllowedVisitor = (
   addToCache = undefined,
 ) => {
   const already = addToCache ? new WeakSet() : undefined;
+  // Do not harden() because ESLint 9 relies on mutating the visitor.
   return {
     /**
      * An `await` expression is treated as non-nested if it is:

--- a/packages/eslint-plugin/lib/tools.js
+++ b/packages/eslint-plugin/lib/tools.js
@@ -73,7 +73,7 @@ const makeAwaitAllowedVisitor = (
   addToCache = undefined,
 ) => {
   const already = addToCache ? new WeakSet() : undefined;
-  return harden({
+  return {
     /**
      * An `await` expression is treated as non-nested if it is:
      * - a non-nested expression statement,
@@ -124,7 +124,7 @@ const makeAwaitAllowedVisitor = (
         makeReport(node);
       }
     },
-  });
+  };
 };
 harden(makeAwaitAllowedVisitor);
 


### PR DESCRIPTION
Refs https://github.com/Agoric/agoric-sdk/issues/10642

ESLint v9 requires visitor objects to be mutable as it needs to modify them internally during rule execution. Our current implementation hardens (freezes) the visitor object returned by `makeAwaitAllowedVisitor`, which causes a TypeError when ESLint tries to modify it.

This PR removes the `harden` call from the visitor object while maintaining hardening on the module exports and other objects where immutability is still desired. This change fixes the TypeError: "Cannot assign to read only property 'AwaitExpression' of object" that was observed when moving `agoric/agoric-sdk` to use ESLint v9

The change only affects the mutability of the visitor object itself, which is necessary for ESLint's internal operations, while preserving our security model everywhere else.