### PR TITLE
fix(eslint-plugin): add missing repository to package.json

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -15,6 +15,11 @@
     "lint-fix": "eslint '**/*.js' --fix",
     "lint": "eslint '**/*.js'"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/Jessie.git",
+    "directory": "packages/eslint-plugin"
+  },
   "dependencies": {
     "requireindex": "~1.1.0"
   },


### PR DESCRIPTION
I was wondering where the heck this plugin came from...
