### PR TITLE
Add homepage and bugs.url package metadata

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -21,6 +21,10 @@
     "url": "git+https://github.com/endojs/Jessie.git",
     "directory": "packages/eslint-plugin"
   },
+  "homepage": "https://github.com/endojs/Jessie/tree/main/packages/eslint-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/endojs/Jessie/issues"
+  },
   "dependencies": {
     "@endo/eslint-plugin": "^2.4.0",
     "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `@jessie.js/eslint-plugin`
- updates only `packages/eslint-plugin/package.json`

## Metadata added
- `homepage`: `https://github.com/endojs/Jessie/tree/main/packages/eslint-plugin#readme`
- `bugs.url`: `https://github.com/endojs/Jessie/issues`

## Validation
- parsed `packages/eslint-plugin/package.json` as JSON after the change
- confirmed the changed manifest still has `name: @jessie.js/eslint-plugin`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package point users to the project README and/or public issue tracker once the package is next released.