### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@jessie.js/eslint-plugin",
   "version": "0.4.3",
+  "homepage": "https://github.com/endojs/Jessie",
+  "bugs": {
+    "url": "https://github.com/endojs/Jessie/issues"
+  },
   "description": "Jessie-specific ESLint plugin",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Adds missing `bugs, repository, homepage` metadata to `packages/eslint-plugin/package.json`.

Fixes npm tooling unable to resolve package metadata.