### PR TITLE
fix(eslint-plugin): support ESLint 10.x

### DIFF
--- a/packages/eslint-plugin/lib/index.js
+++ b/packages/eslint-plugin/lib/index.js
@@ -34,7 +34,31 @@ module.exports = plugin;
 
 const { recommended, ...rest } = requireIndex(`${__dirname}/configs`);
 const configMakers = { recommended, ...rest };
+
+plugin.configs = {};
+
+// Importing this plugin must NOT eagerly evaluate any config: some configs
+// (notably `internal`) call `FlatCompat.extends('plugin:@endo/strict', ...)` at
+// construction time. This pulls in `@endo/eslint-plugin`'s legacy config whose
+// transitively-referenced plugins (e.g., `eslint-plugin-jsdoc`) are resolved
+// relative to *this* package's directory. We have no guarantee that any given
+// transitive dep is resolvable from here!
+// Lazy eval sidesteps this entirely for flat-config consumers.
 for (const [name, configMaker] of Object.entries(configMakers)) {
-  plugin.configs[`flat/${name}`] = configMaker(plugin);
-  plugin.configs[name] = configMaker();
+  let legacyConfig;
+  let flatConfig;
+  Object.defineProperty(plugin.configs, name, {
+    enumerable: true,
+    get: () => {
+      legacyConfig ??= configMaker();
+      return legacyConfig;
+    },
+  });
+  Object.defineProperty(plugin.configs, `flat/${name}`, {
+    enumerable: true,
+    get: () => {
+      flatConfig ??= configMaker(plugin);
+      return flatConfig;
+    },
+  });
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -27,7 +27,7 @@
     "requireindex": "~1.1.0"
   },
   "peerDependencies": {
-    "eslint": "^8 || ^9"
+    "eslint": "^8 || ^9 || ^10"
   },
   "devDependencies": {
     "mocha": "^10.2.0"


### PR DESCRIPTION
This adds implicit support for ESLint 10.x to `@jessie.js/eslint-plugin`.

- Bump peer dep of `@jessie.js/eslint-plugin` to allow ESLint 10.x
- Made configs lazily-loaded so a flat-config user does not run into resolution issues (see comment in `index.js`)

This repo cannot upgrade to ESLint 10.x internally until `@endo/eslint-plugin` establishes support (ref: https://github.com/endojs/endo/pull/3319). The linked PR also shows the workaround necessary (see `.yarnrc.yml`) due to the eager loading issue fixed in this change.